### PR TITLE
ci: avoid duplication of workflow runs in pull requests

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -1,5 +1,10 @@
 name: mypy
-on: [push, pull_request]
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
 
 permissions: {}
 

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,5 +1,10 @@
 name: Ruff (Python linter)
-on: [push, pull_request]
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
 
 permissions: {}
 

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -1,5 +1,10 @@
 name: Python unit tests
-on: [push, pull_request]
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
 
 permissions: {}
 


### PR DESCRIPTION
This restricts push-triggered workflows to the main branch, preventing workflows from being run twice on pull requests from branches of this repository.