### PR TITLE
fix: prevent SELinux denial with certain custom editors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+
+- Fixed issue with SELinux denying certain custom editors set via `--editor`.
+
 ## [v0.5.1] - 2025-06-17
 
 - Warn about likely incorrect usage when the user passes multiple positional
@@ -100,6 +104,7 @@ Rewrote script in Python.
 
 - Initial release.
 
+[Unreleased]: https://github.com/HastD/run0edit/compare/v0.5.1...HEAD
 [v0.5.1]: https://github.com/HastD/run0edit/compare/v0.5.0...v0.5.1
 [v0.5.0]: https://github.com/HastD/run0edit/compare/v0.4.4...v0.5.0
 [v0.4.4]: https://github.com/HastD/run0edit/compare/v0.4.3...v0.4.4

--- a/run0edit_inner.py
+++ b/run0edit_inner.py
@@ -326,7 +326,8 @@ def handle_copy_to_original(
 def run_editor(*, uid: int, editor: str, path: str) -> None:
     """Run the editor as the given UID to edit the file at the given path."""
     try:
-        run_command("run0", f"--user={uid}", "--", editor, path)
+        sh = find_command("sh")
+        run_command("run0", f"--user={uid}", "--", sh, "-c", '"$1" "$2"', sh, editor, path)
     except CommandNotFoundError as e:
         print("run0edit: failed to call run0 to start editor")
         raise EditTempFileError from e

--- a/run0edit_main.py
+++ b/run0edit_main.py
@@ -59,7 +59,7 @@ from typing import Final, Union
 
 __version__: Final[str] = "0.5.1"
 INNER_SCRIPT_PATH: Final[str] = "/usr/libexec/run0edit/run0edit_inner.py"
-INNER_SCRIPT_SHA256: Final[str] = "b261a1e8f8cc1c06d87f48c46edc510dcdd916723eb6ce6dfb5f914318df4996"
+INNER_SCRIPT_SHA256: Final[str] = "d87a2d54f665e9a9cfd83ce7f9e8e3b852ab6c22fc62f1209c4523424bfc3161"
 DEFAULT_CONF_PATH: Final[str] = "/etc/run0edit/editor.conf"
 
 SYSTEM_CALL_DENY: Final[list[str]] = [

--- a/test/test_run0edit_inner.py
+++ b/test/test_run0edit_inner.py
@@ -531,12 +531,17 @@ class TestHandleCopyToOriginal(TestCaseWithFiles):
 class TestRunEditor(unittest.TestCase):
     """Tests for run_editor"""
 
-    def test_check_args(self, mock_run_cmd, mock_stdout):
+    @mock.patch("run0edit_inner.find_command")
+    def test_check_args(self, mock_find_cmd, mock_run_cmd, mock_stdout):
         """Should pass correct arguments to run_command"""
         editor = mock.sentinel.editor
         path = mock.sentinel.path
+        mock_find_cmd.side_effect = lambda cmd: f"/bin/{cmd}"
         inner.run_editor(uid=42, editor=editor, path=path)
-        self.assertEqual(mock_run_cmd.call_args.args, ("run0", "--user=42", "--", editor, path))
+        self.assertEqual(
+            mock_run_cmd.call_args.args,
+            ("run0", "--user=42", "--", "/bin/sh", "-c", '"$1" "$2"', "/bin/sh", editor, path),
+        )
         self.assertEqual(mock_stdout.getvalue(), "")
 
     def test_error_messages(self, mock_run_cmd, mock_stdout):


### PR DESCRIPTION
Previously, if the user chose an editor that didn't have the right SELinux label (e.g. if it was in the user's home directory instead of a directory like `/usr/bin` labeled for executables), the inner `run0` command to run the editor would fail with status 203. This works around the issue by wrapping the editor command in `sh -c`.