### PR TITLE
build: use remote source in RPM spec

### DIFF
--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -45,6 +45,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Modify RPM spec to use local source
+        run: sed -Ei '/^Source0:/s/https:\/\/.*/%{name}-%{version}.tar.gz/' rpm/run0edit.spec
+
       - name: Retrieve source archive
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:

--- a/rpm/run0edit.spec
+++ b/rpm/run0edit.spec
@@ -5,7 +5,7 @@ Summary:        run0edit allows a permitted user to edit a file as root.
 
 License:        Apache-2.0 OR MIT
 URL:            https://github.com/HastD/%{name}
-Source:         %{name}-%{version}.tar.gz
+Source0:        https://github.com/HastD/%{name}/archive/refs/tags/v%{version}.tar.gz
 
 BuildArch:      noarch
 Requires:       python3 >= 3.9


### PR DESCRIPTION
This should make Copr builds simpler since they can just use the spec file directly instead of the SRPM. For the GitHub actions workflow, we just edit the spec locally to use the local source.