### PR TITLE
fix: casefold() instead of lower() for case-insensitive equality

### DIFF
--- a/run0edit_inner.py
+++ b/run0edit_inner.py
@@ -170,7 +170,7 @@ def should_remove_immutable(path: str, is_dir: bool) -> bool:
     else:
         prompt = "Temporarily remove the attribute to edit the file? [y/N] "
     response = input(prompt)
-    return response.lower().startswith("y")
+    return response.casefold().startswith("y")
 
 
 def check_readonly(

--- a/run0edit_main.py
+++ b/run0edit_main.py
@@ -59,7 +59,7 @@ from typing import Final, Union
 
 __version__: Final[str] = "0.5.2"
 INNER_SCRIPT_PATH: Final[str] = "/usr/libexec/run0edit/run0edit_inner.py"
-INNER_SCRIPT_SHA256: Final[str] = "d87a2d54f665e9a9cfd83ce7f9e8e3b852ab6c22fc62f1209c4523424bfc3161"
+INNER_SCRIPT_SHA256: Final[str] = "b206d13b19267bab87dc18628462cafb70885076cc0fda7713d9e910600aa787"
 DEFAULT_CONF_PATH: Final[str] = "/etc/run0edit/editor.conf"
 
 SYSTEM_CALL_DENY: Final[list[str]] = [
@@ -416,7 +416,7 @@ def catch_usage_mistake(paths: list[str], *, prompt: bool = True) -> None:
         absolute path to {DEFAULT_CONF_PATH}.
     """)
     response = input(f"\nDo you really want to edit the file ./{arg}? [y/N] ")
-    if not response.lower().startswith("y"):
+    if not response.casefold().startswith("y"):
         raise UsageError
 
 

--- a/test/test_run0edit_inner.py
+++ b/test/test_run0edit_inner.py
@@ -168,7 +168,7 @@ class TestShouldRemoveImmutable(unittest.TestCase):
         path = "/etc"
         for answer in answers:
             result = inner.should_remove_immutable(path, is_dir=True)
-            self.assertEqual(result, answer.lower().startswith("y"))
+            self.assertEqual(result, answer.casefold().startswith("y"))
 
 
 class TestCaseWithFiles(unittest.TestCase):


### PR DESCRIPTION
Unlikely to matter in practice but it's technically correct.