### PR TITLE
test: add integration test for creating file in unreadable dir

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ pylint.max-statements = 30
 [tool.ruff.lint.per-file-ignores]
 # Ignore "too many function arguments" and "private member accessed" in tests
 "test/**.py" = ["PLR0913", "SLF001"]
+"integration-test/**.py" = ["PLR0913", "SLF001"]
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
Test that run0edit successfully creates a new file in a directory that's only readable by root, not the unprivileged user.