### PR TITLE
fix: clearer error message if path is in privileged location

### DIFF
--- a/run0edit_main.py
+++ b/run0edit_main.py
@@ -390,7 +390,11 @@ def run(path: str, editor: str, *, debug: bool = False, no_prompt: bool = False)
         # If directory does not exist, namespace creation will fail, causing
         # run0 to fail with exit status 226:
         # https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html
-        print_err(f"No such directory {os.path.dirname(path)}")
+        # This can also occur if the path is privileged (such as /etc/shadow)
+        # and SELinux is enabled and blocks systemd from mounting the namespace.
+        print_err(
+            f"No such directory {os.path.dirname(path)}, or path is in a privileged location."
+        )
         temp_file.remove()
         return 1
     if process.returncode != 0:


### PR DESCRIPTION
SELinux can prevent systemd from mounting on privileged locations such as /etc/shadow, causing namespace setup to fail. Normally this only happens when the directory doesn't exist, so the error message was misleading.