### PR TITLE
chore!: drop support for Python 3.9

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:

--- a/integration-test/integration_tests.py
+++ b/integration-test/integration_tests.py
@@ -10,7 +10,7 @@ import secrets
 import subprocess  # nosec
 import tempfile
 import unittest
-from typing import Final, Union
+from typing import Final
 
 RUN0: Final[str] = "/usr/bin/run0"
 EDITOR: Final[str] = os.path.realpath("./integration-test/mock-editor.sh")
@@ -44,7 +44,7 @@ class TestFile:
 
     def __init__(
         self,
-        directory: Union[str, None] = None,
+        directory: str | None = None,
         *,
         root_owned: bool = True,
         immutable: bool = False,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "run0edit"
 version = "0.5.3"
-requires-python = ">= 3.9"
+requires-python = ">= 3.10"
 authors = [{name = "Daniel Hast"}]
 maintainers = [{name = "Daniel Hast"}]
 description = "run0edit allows a permitted user to edit a file as root using run0."

--- a/rpm/run0edit.spec
+++ b/rpm/run0edit.spec
@@ -8,7 +8,7 @@ URL:            https://github.com/HastD/%{name}
 Source0:        https://github.com/HastD/%{name}/archive/refs/tags/v%{version}.tar.gz
 
 BuildArch:      noarch
-Requires:       python3 >= 3.9
+Requires:       python3 >= 3.10
 Requires:       systemd >= 256
 Recommends:     e2fsprogs
 
@@ -36,6 +36,9 @@ install -m 644 %{name}_inner.py %{buildroot}%{_libexecdir}/%{name}/%{name}_inner
 %{_libexecdir}/%{name}
 
 %changelog
+* Tues Oct 07 2025 Daniel Hast <hast.daniel@protonmail.com> v0.5.4
+  - Update to version 0.5.4
+  - Increase minimum required Python version to 3.10.
 * Mon Aug 18 2025 Daniel Hast <hast.daniel@protonmail.com> v0.5.3
   - Update to version 0.5.3
   - Specify remote source URL to simplify Copr builds.

--- a/run0edit_inner.py
+++ b/run0edit_inner.py
@@ -50,7 +50,6 @@ import stat
 import subprocess  # nosec
 import sys
 from collections.abc import Sequence
-from typing import Union
 
 
 class Run0editError(Exception):
@@ -101,7 +100,7 @@ class FileContentsMismatchError(Run0editError):
     """File contents are not what they should be."""
 
 
-def readonly_filesystem(path: str) -> Union[bool, None]:
+def readonly_filesystem(path: str) -> bool | None:
     """Determine if the path is on a read-only filesystem."""
     try:
         return bool(os.statvfs(path).f_flag & os.ST_RDONLY)
@@ -117,7 +116,7 @@ def find_command(command: str) -> str:
     return cmd_path
 
 
-def run_command(cmd: str, *args: str, capture_output: bool = False) -> Union[str, None]:
+def run_command(cmd: str, *args: str, capture_output: bool = False) -> str | None:
     """Run command as subprocess."""
     run_args = [find_command(cmd), *args]
     try:
@@ -385,7 +384,7 @@ def parse_args(args: Sequence[str]) -> tuple[str, str, str]:
     return args[0], args[1], args[2]
 
 
-def main(args: Sequence[str], *, uid: Union[int, None] = None) -> int:
+def main(args: Sequence[str], *, uid: int | None = None) -> int:
     """Main function."""
     try:
         original_file, temp_file, editor = parse_args(args)

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -5,12 +5,12 @@
 import os
 import shutil
 import tempfile
-from typing import Final, Union
+from typing import Final
 
 TEMP_FILE_PREFIX: Final[str] = "run0edit-unittest-"
 
 
-def new_test_file(contents: bytes = b"", *, mode: Union[int, None] = None) -> str:
+def new_test_file(contents: bytes = b"", *, mode: int | None = None) -> str:
     """Make a temporary file with the given contents."""
     path = tempfile.mkstemp(prefix=TEMP_FILE_PREFIX)[1]
     if contents:


### PR DESCRIPTION
As of October 2025, Python 3.9 is end-of-life and no longer receiving security updates. For that reason, run0edit is dropping Python 3.9 support and now has a minimum required Python version of 3.10.

This allows for a couple changes that improve code readability: the use of `|` instead of `Union` for sum type annotations, and the use of `match` blocks.