### PR TITLE
fix: switch priority of editor conf file and env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ The choice of editor can be customized by writing the path to a text editor (for
 example, `/usr/bin/vim`) to one of the following (listed in order of priority):
 
 - The `--editor` command-line argument to `run0edit`;
-- The environment variables `VISUAL` or `EDITOR`; or
-- The file `/etc/run0edit/editor.conf` (must be an absolute path).
+- The file `/etc/run0edit/editor.conf` (must be an absolute path); or
+- The environment variables `VISUAL` or `EDITOR`.
 
 If none of these point to an executable file, `run0edit` will default to using
 `nano` or `vi`.

--- a/run0edit_main.py
+++ b/run0edit_main.py
@@ -170,16 +170,16 @@ def get_fallback_editor_path(fallbacks: Sequence[str] | None = None) -> str | No
 
 
 def get_editor_path(provided_editor: str | None = None) -> str:
-    """Get the editor path from a provided path, conf file, or fallback."""
+    """Get the editor path from a provided path, conf file, env var, or fallback."""
     if provided_editor is not None:
         editor_path = shutil.which(provided_editor)
         if editor_path is None:
             raise InvalidProvidedEditorError(provided_editor)
         return os.path.realpath(provided_editor)
-    editor = get_editor_path_from_env()
+    editor = get_editor_path_from_conf()
     if editor is not None:
         return editor
-    editor = get_editor_path_from_conf()
+    editor = get_editor_path_from_env()
     if editor is not None:
         return editor
     editor = get_fallback_editor_path()

--- a/test/test_run0edit_main.py
+++ b/test/test_run0edit_main.py
@@ -255,47 +255,47 @@ class TestGetEditorPath(unittest.TestCase):
         """Should return provided editor path if valid"""
         editor = run0edit.get_editor_path("/bin/true")
         self.assertEqual(editor, os.path.realpath("/bin/true"))
-        self.assertFalse(mock_from_env.called)
         self.assertFalse(mock_from_conf.called)
+        self.assertFalse(mock_from_env.called)
         self.assertFalse(mock_fallback.called)
 
     def test_invalid_provided(self, mock_from_conf, mock_from_env, mock_fallback):
         """Should raise exception if provided invalid editor path"""
         with self.assertRaisesRegex(run0edit.InvalidProvidedEditorError, "/dev/null"):
             run0edit.get_editor_path("/dev/null")
+        self.assertFalse(mock_from_conf.called)
         self.assertFalse(mock_from_env.called)
-        self.assertFalse(mock_from_conf.called)
         self.assertFalse(mock_fallback.called)
 
-    def test_gets_from_env_if_not_provided(self, mock_from_conf, mock_from_env, mock_fallback):
+    def test_gets_from_conf_if_not_provided(self, mock_from_conf, mock_from_env, mock_fallback):
         """Should get editor from environment if not provided"""
-        editor = mock.sentinel.editor_from_env
-        mock_from_env.return_value = editor
-        self.assertEqual(run0edit.get_editor_path(), editor)
-        self.assertEqual(mock_from_env.call_count, 1)
-        self.assertFalse(mock_from_conf.called)
-        self.assertFalse(mock_fallback.called)
-
-    def test_gets_from_conf_if_not_from_env(self, mock_from_conf, mock_from_env, mock_fallback):
-        """Should get editor from conf file if not provided or found in environment"""
         editor = mock.sentinel.editor_from_conf
-        mock_from_env.return_value = None
         mock_from_conf.return_value = editor
         self.assertEqual(run0edit.get_editor_path(), editor)
-        self.assertEqual(mock_from_env.call_count, 1)
-        self.assertEqual(mock_from_conf.call_args, ((), {}))
+        self.assertEqual(mock_from_conf.call_args_list, [((), {})])
+        self.assertFalse(mock_from_env.called)
+        self.assertFalse(mock_fallback.called)
+
+    def test_gets_from_env_if_not_from_conf(self, mock_from_conf, mock_from_env, mock_fallback):
+        """Should get editor from environment if not provided or found in conf file"""
+        editor = mock.sentinel.editor_from_env
+        mock_from_conf.return_value = None
+        mock_from_env.return_value = editor
+        self.assertEqual(run0edit.get_editor_path(), editor)
+        self.assertEqual(mock_from_conf.call_args_list, [((), {})])
+        self.assertEqual(mock_from_env.call_args_list, [((), {})])
         self.assertFalse(mock_fallback.called)
 
     def test_gets_fallback_if_no_conf(self, mock_from_conf, mock_from_env, mock_fallback):
         """Should get editor from conf file if not provided"""
         editor = mock.sentinel.fallback_editor
-        mock_from_env.return_value = None
         mock_from_conf.return_value = None
+        mock_from_env.return_value = None
         mock_fallback.return_value = editor
         self.assertEqual(run0edit.get_editor_path(), editor)
-        self.assertEqual(mock_from_env.call_count, 1)
-        self.assertEqual(mock_from_conf.call_args, ((), {}))
-        self.assertEqual(mock_fallback.call_args, ((), {}))
+        self.assertEqual(mock_from_conf.call_args_list, [((), {})])
+        self.assertEqual(mock_from_env.call_args_list, [((), {})])
+        self.assertEqual(mock_fallback.call_args_list, [((), {})])
 
     def test_no_conf_no_fallback(self, mock_from_conf, mock_from_env, mock_fallback):
         """Should raise expected error if fallback fails to find editor"""
@@ -304,9 +304,9 @@ class TestGetEditorPath(unittest.TestCase):
         mock_fallback.return_value = None
         with self.assertRaises(run0edit.EditorNotFoundError):
             run0edit.get_editor_path()
-        self.assertEqual(mock_from_env.call_count, 1)
-        self.assertEqual(mock_from_conf.call_args, ((), {}))
-        self.assertEqual(mock_fallback.call_args, ((), {}))
+        self.assertEqual(mock_from_conf.call_args_list, [((), {})])
+        self.assertEqual(mock_from_env.call_args_list, [((), {})])
+        self.assertEqual(mock_fallback.call_args_list, [((), {})])
 
 
 @mock.patch("run0edit_main.get_editor_path")


### PR DESCRIPTION
The configuration file is specific to run0edit, while the environment variables are non-specific and are also set by default to nano on many systems. So, the configuration file should be higher-priority for editor selection.