### PR TITLE
feat: ignore comment lines in editor.conf

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright 2026 run0edit authors (https://github.com/HastD/run0edit)
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+indent_size = 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 
 # Changelog
 
+## [Unreleased]
+
+- Ignore comment lines and empty lines in `/etc/run0edit/editor.conf`.
+
 ## [v0.5.9] - 2026-05-06
 
 - Make the configuration file at `/etc/run0edit/editor.conf` higher priority
@@ -181,6 +185,7 @@ Rewrote script in Python. ([#1](https://github.com/HastD/run0edit/pull/1))
 
 - Initial release.
 
+[Unreleased]: https://github.com/HastD/run0edit/compare/v0.5.9...HEAD
 [v0.5.9]: https://github.com/HastD/run0edit/compare/v0.5.8...v0.5.9
 [v0.5.8]: https://github.com/HastD/run0edit/compare/v0.5.7...v0.5.8
 [v0.5.7]: https://github.com/HastD/run0edit/compare/v0.5.6...v0.5.7

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,0 +1,6 @@
+version = 1
+
+[[annotations]]
+path = "data/editor.conf"
+SPDX-FileCopyrightText = "(c) 2026 run0edit authors (https://github.com/HastD/run0edit)"
+SPDX-License-Identifier = "Apache-2.0 OR MIT"

--- a/data/editor.conf
+++ b/data/editor.conf
@@ -1,0 +1,5 @@
+# This file allows configuring the default editor for run0edit.
+#
+# The first uncommented, non-empty line should be an absolute path to
+# the chosen default text editor. If no such line is present, this file
+# will be ignored.

--- a/rpm/run0edit.spec
+++ b/rpm/run0edit.spec
@@ -32,54 +32,52 @@ copied back to the original location when the editor is closed.
 %build
 
 %install
-%define inner_script_dir %{_libexecdir}/%{name}
-%define inner_script_file %{inner_script_dir}/%{name}_inner.py
-
-%define editor_conf_dir %{_sysconfdir}/%{name}
-%define editor_conf_file %{editor_conf_dir}/editor.conf
-
-mkdir -m 755 -p %{buildroot}%{_bindir} %{buildroot}%{inner_script_dir} %{buildroot}%{editor_conf_dir}
-
-install -m 755 %{name}_main.py %{buildroot}%{_bindir}/%{name}
-install -m 644 %{name}_inner.py %{buildroot}%{inner_script_file}
-
-touch %{buildroot}%{editor_conf_file}
-chmod 644 %{buildroot}%{editor_conf_file}
+install -Dp -m 755 -t %{buildroot}%{_bindir} %{name}_main.py
+install -Dp -m 644 -t %{buildroot}%{_libexecdir}/%{name} %{name}_inner.py
+install -Dp -m 644 -t %{buildroot}%{_sysconfdir}/%{name} data/editor.conf
 
 %files
 %{_bindir}/%{name}
-%{inner_script_dir}
-%config(noreplace) %{editor_conf_dir}
+%{_libexecdir}/%{name}
+%config(noreplace) %{_sysconfdir}/%{name}
 
 %changelog
-* Wed May 06 2026 Daniel Hast <hast.daniel@protonmail.com> v0.5.9
-  - Update to version 0.5.9
-* Thu Mar 12 2026 Daniel Hast <hast.daniel@protonmail.com> v0.5.8
-  - Update to version 0.5.8
-* Wed Feb 11 2026 Daniel Hast <hast.daniel@protonmail.com> v0.5.7
-  - Update to version 0.5.7
-* Mon Dec 22 2025 Daniel Hast <hast.daniel@protonmail.com> v0.5.6
-  - Update to version 0.5.6
-  - Add editor config file to RPM spec so it's automatically created with the
-    expected permissions on install.
-* Tue Oct 28 2025 Daniel Hast <hast.daniel@protonmail.com> v0.5.5
-  - Update to version 0.5.5
-* Wed Oct 15 2025 Daniel Hast <hast.daniel@protonmail.com> v0.5.4
-  - Update to version 0.5.4
-  - Increase minimum required Python version to 3.10.
-  - Add python3-devel build dependency.
-* Mon Aug 18 2025 Daniel Hast <hast.daniel@protonmail.com> v0.5.3
-  - Update to version 0.5.3
-  - Specify remote source URL to simplify Copr builds.
+* Wed May 06 2026 Daniel Hast <hast.daniel@protonmail.com> - v0.5.9
+- Make the global configuration file higher priority than environment variables
+  for editor selection.
+
+* Thu Mar 12 2026 Daniel Hast <hast.daniel@protonmail.com> - v0.5.8
+- Make temporary files have same base filename as the original file.
+- Allow non-absolute editor specifications in environment variables.
+
+* Wed Feb 11 2026 Daniel Hast <hast.daniel@protonmail.com> - v0.5.7
+- Allow specifying editor via environment variables.
+- Use BLAKE2 instead of SHA-256 for inner script checksum.
+
+* Mon Dec 22 2025 Daniel Hast <hast.daniel@protonmail.com> - v0.5.6
+- Add editor config file to RPM spec so it's automatically created with the
+  expected permissions on install.
+
+* Tue Oct 28 2025 Daniel Hast <hast.daniel@protonmail.com> - v0.5.5
+- Add `--background` option to set or disable background color.
+
+* Wed Oct 15 2025 Daniel Hast <hast.daniel@protonmail.com> - v0.5.4
+- Increase minimum required Python version to 3.10.
+- Improve error messages.
+
+* Mon Aug 18 2025 Daniel Hast <hast.daniel@protonmail.com> - v0.5.3
+- Exit with an error if config file exists but is unreadable.
+
 * Sat Jun 21 2025 Daniel Hast <hast.daniel@protonmail.com> v0.5.2
-  - Update to version 0.5.2
-* Tue Jun 17 2025 Daniel Hast <hast.daniel@protonmail.com> v0.5.1
-  - Update to version 0.5.1
-* Mon Jun 16 2025 Daniel Hast <hast.daniel@protonmail.com> v0.5.0
-  - Update to version 0.5.0
-  - Python rewrite: install Python scripts in place of old shell script
-  - Fix systemd and Python version requirements
-  - Add `Recommends: e2fsprogs` for immutable attribute support.
-  - Remove `BuildRequires: python3` as there's no longer a build process.
-* Thu May 22 2025 Daniel Hast <hast.daniel@protonmail.com> v0.4.4
-  - Initial RPM release
+- Fixed sandbox bug.
+- Fixed SELinux denying certain custom editors.
+
+* Tue Jun 17 2025 Daniel Hast <hast.daniel@protonmail.com> - v0.5.1
+- Warn about likely incorrect usage with first argument that looks like a
+  command name.
+
+* Mon Jun 16 2025 Daniel Hast <hast.daniel@protonmail.com> - v0.5.0
+- Rewrote script in Python
+
+* Thu May 22 2025 Daniel Hast <hast.daniel@protonmail.com> - v0.4.4
+- Initial RPM release

--- a/run0edit_main.py
+++ b/run0edit_main.py
@@ -132,7 +132,8 @@ def get_editor_path_from_conf(conf_path: str = DEFAULT_CONF_PATH) -> str | None:
     """Get path to editor executable from conf file."""
     try:
         with open(conf_path, encoding="utf8") as f:
-            editor = f.read().strip()
+            # Get the first non-empty line that doesn't start with "#"
+            editor = next((line for line in map(str.strip, f) if not line.startswith("#")), None)
     except PermissionError as e:
         raise UnreadableEditorConfError from e
     except OSError:

--- a/test/test_run0edit_main.py
+++ b/test/test_run0edit_main.py
@@ -138,9 +138,22 @@ class TestGetEditorPathFromConf(unittest.TestCase):
         self.assertEqual(editor, "/bin/true")
         remove_test_file(conf)
 
+    def test_read_conf_path_valid_with_comment(self):
+        """Should read and validate editor path from conf file, ignoring comment lines"""
+        conf = new_test_file(b"# this is a comment\n/bin/true \n")
+        editor = run0edit.get_editor_path_from_conf(conf)
+        self.assertEqual(editor, "/bin/true")
+        remove_test_file(conf)
+
     def test_read_conf_path_empty(self):
         """Should ignore empty conf file"""
-        conf = new_test_file(b"\n")
+        conf = new_test_file(b"")
+        self.assertIsNone(run0edit.get_editor_path_from_conf(conf))
+        remove_test_file(conf)
+
+    def test_read_conf_path_only_comments(self):
+        """Should ignore empty conf file"""
+        conf = new_test_file(b"# this is a comment\n  # another comment\n")
         self.assertIsNone(run0edit.get_editor_path_from_conf(conf))
         remove_test_file(conf)
 


### PR DESCRIPTION
This allows editor.conf to be created by default with some comments explaining its usage.

Also add editorconfig file to set basic file formatting and encoding conventions, and make the changelog in the RPM spec actually useful.