### PR TITLE
build: switch to Meson build system

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,5 +12,5 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[*.md]
+[*.{md,yaml,yml}]
 indent_size = 2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,29 +17,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  mypy:
-    name: mypy
-    runs-on: ubuntu-slim
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
-      - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
-        with:
-          python-version: "3.14"
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install mypy
-
-      - name: Run mypy
-        run: |
-          PATH="$HOME/.local/bin:$PATH"
-          mypy .
-
   reuse:
     name: REUSE spec compliance
     runs-on: ubuntu-slim
@@ -71,49 +48,3 @@ jobs:
         shell: bash
         run: |
           rpmlint rpm/run0edit.spec
-
-  ruff:
-    name: Ruff (Python linter)
-    runs-on: ubuntu-slim
-    strategy:
-      matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install ruff
-
-      - name: Run Ruff
-        run: ruff check --output-format=github .
-
-      - name: Check code formatting
-        run: ruff format --diff
-
-  shellcheck:
-    name: Run ShellCheck on shell scripts
-    runs-on: ubuntu-slim
-    steps:
-      - name: Install dependencies
-        shell: bash
-        run: |
-          sudo apt update
-          sudo apt install shellcheck
-
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
-      - name: Run ShellCheck
-        shell: bash
-        run: |
-          find . -type f -name '*.sh' -execdir shellcheck '{}' +

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,8 +18,12 @@ concurrency:
 
 jobs:
   unittest:
-    name: Run unit tests & report coverage
-    runs-on: ubuntu-slim
+    name: Run Python unit tests and linters
+    runs-on: ubuntu-26.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -28,20 +32,17 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
-          python-version: "3.14"
+          python-version: ${{ matrix.python-version }}
 
-      - name: Install coverage.py
+      - name: Install dependencies
         run: |
           python3 -m pip install --upgrade pip
-          pip install coverage
+          pip install coverage meson ruff ty
+          sudo apt install just
 
-      - name: Run unit tests
+      - name: Run tests
         run: |
-          coverage run -m unittest
-
-      - name: Report coverage
-        run: |
-          coverage report -m --skip-empty --fail-under=100
+          just test
 
   integration-test:
     name: Run integration tests
@@ -56,6 +57,11 @@ jobs:
         with:
           python-version: "3.14"
 
+      - name: Install dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          pip install meson
+
       - name: Set up passwordless authentication
         run: |
           cat <<EOF | sudo tee /etc/polkit-1/rules.d/10-systemd-nopasswd.rules >/dev/null
@@ -68,4 +74,7 @@ jobs:
 
       - name: Run integration tests
         run: |
-          python3 -m unittest integration-test/integration_tests.py
+          mkdir -p build
+          meson setup build -Dprefix=/usr -Dunit-tests=disabled -Dintegration-tests=enabled
+          meson compile -C build
+          meson test -C build --verbose integration-test

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@
 .ssh
 .venv
 __pycache__
+build
 uv.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 ## [Unreleased]
 
 - Ignore comment lines and empty lines in `/etc/run0edit/editor.conf`.
+- Switch to using Meson build system.
 
 ## [v0.5.9] - 2026-05-06
 

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright 2026 run0edit authors (https://github.com/HastD/run0edit)
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+[default]
+@_default:
+    just --list
+
+build:
+    mkdir -p build
+    meson setup build -Dprefix=/usr
+    meson compile -C build
+
+clean:
+    rm -rf build
+
+test: build
+    meson test -C build --verbose

--- a/data/meson.build
+++ b/data/meson.build
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright 2026 run0edit authors (https://github.com/HastD/run0edit)
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+install_data(
+    'editor.conf',
+    install_dir: sysconfdir / meson.project_name(),
+    install_tag: 'config',
+)

--- a/integration-test/meson.build
+++ b/integration-test/meson.build
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright 2026 run0edit authors (https://github.com/HastD/run0edit)
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+fs = import('fs')
+fs.copyfile('integration_tests.py')
+fs.copyfile('mock-editor.sh')
+
+if get_option('integration-tests').enabled()
+    test(
+        'integration-test',
+        find_program('python3'),
+        args: ['-m', 'unittest', 'integration-test/integration_tests.py'],
+        is_parallel: false,
+    )
+endif

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: Copyright 2026 run0edit authors (https://github.com/HastD/run0edit)
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+project(
+    'run0edit',
+    version: '0.5.9',
+    meson_version: '>= 1.3.0',
+    license: 'Apache-2.0 OR MIT',
+)
+
+fs = import('fs')
+
+prefixdir = get_option('prefix')
+bindir = get_option('bindir')
+libexecdir = prefixdir / get_option('libexecdir')
+datadir = prefixdir / get_option('datadir')
+sysconfdir = get_option('sysconfdir')
+
+conf_data = configuration_data()
+conf_data.set('VERSION', meson.project_version())
+conf_data.set('BINDIR', bindir)
+conf_data.set('LIBEXECDIR', libexecdir)
+conf_data.set('SYSCONFDIR', sysconfdir)
+
+main_script = configure_file(
+    input: 'run0edit_main.py.in',
+    output: 'run0edit_main.py',
+    configuration: conf_data,
+)
+
+install_data(
+    main_script,
+    rename: 'run0edit',
+    install_dir: bindir,
+    install_mode: 'rwxr-xr-x',
+)
+
+fs.copyfile(
+    'run0edit_inner.py',
+    install: true,
+    install_dir: libexecdir / meson.project_name(),
+)
+
+licensedir = get_option('licensedir')
+if licensedir == ''
+    licensedir = datadir / 'licenses' / meson.project_name()
+endif
+licenses = [
+    './LICENSES/Apache-2.0.txt',
+    './LICENSES/MIT.txt',
+]
+install_data(
+    licenses,
+    install_dir: licensedir,
+)
+
+fs.copyfile('pyproject.toml')
+fs.copyfile('run0edit-local')
+
+subdir('data')
+subdir('test')
+subdir('integration-test')
+
+if get_option('unit-tests').enabled()
+    ruff = find_program('ruff')
+    test('format', ruff, args: ['format', '--diff', '--no-respect-gitignore'])
+    test('lint', ruff, args: ['check', '--no-respect-gitignore'])
+    test('type-check', find_program('ty'), args: ['check', '--no-respect-ignore-files'])
+endif
+
+summary({
+    'unit-tests': get_option('unit-tests'),
+    'integration-tests': get_option('integration-tests'),
+})

--- a/meson.options
+++ b/meson.options
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright 2026 run0edit authors (https://github.com/HastD/run0edit)
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+option(
+  'unit-tests',
+  type: 'feature',
+  description: 'enable unit tests',
+  value: 'enabled',
+)
+
+option(
+  'integration-tests',
+  type: 'feature',
+  description: 'enable integration tests',
+  value: 'disabled',
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,17 +21,6 @@ license-files = ["LICENSES/*.txt"]
 Repository = "https://github.com/HastD/run0edit"
 Issues = "https://github.com/HastD/run0edit/issues"
 
-[tool.mypy]
-strict = true
-
-[[tool.mypy.overrides]]
-module = "test.*"
-disallow_untyped_defs = false
-
-[[tool.mypy.overrides]]
-module = "integration_tests"
-disallow_untyped_defs = false
-
 [tool.ruff]
 line-length = 100
 

--- a/rpm/run0edit.spec
+++ b/rpm/run0edit.spec
@@ -12,7 +12,11 @@ URL:            https://github.com/HastD/%{name}
 Source0:        https://github.com/HastD/%{name}/archive/refs/tags/v%{version}.tar.gz
 
 BuildArch:      noarch
+BuildRequires:  meson
+BuildRequires:  python3-coverage
 BuildRequires:  python3-devel >= 3.10
+BuildRequires:  ruff
+BuildRequires:  ty
 Requires:       python3 >= 3.10
 Requires:       systemd >= 256
 Recommends:     e2fsprogs
@@ -30,16 +34,20 @@ copied back to the original location when the editor is closed.
 %autosetup
 
 %build
+%meson
+%meson_build
 
 %install
-install -Dp -m 755 -t %{buildroot}%{_bindir} %{name}_main.py
-install -Dp -m 644 -t %{buildroot}%{_libexecdir}/%{name} %{name}_inner.py
-install -Dp -m 644 -t %{buildroot}%{_sysconfdir}/%{name} data/editor.conf
+%meson_install
+
+%check
+%meson_test
 
 %files
 %{_bindir}/%{name}
 %{_libexecdir}/%{name}
 %config(noreplace) %{_sysconfdir}/%{name}
+%license %{_defaultlicensedir}/%{name}
 
 %changelog
 * Wed May 06 2026 Daniel Hast <hast.daniel@protonmail.com> - v0.5.9

--- a/run0edit_main.py.in
+++ b/run0edit_main.py.in
@@ -25,11 +25,11 @@ from collections.abc import Sequence
 from pathlib import Path
 from typing import Final
 
-__version__: Final[str] = "0.5.9"
-INNER_SCRIPT_PATH: Final[str] = "/usr/libexec/run0edit/run0edit_inner.py"
+__version__: Final[str] = "@VERSION@"
+INNER_SCRIPT_PATH: Final[str] = "@LIBEXECDIR@/run0edit/run0edit_inner.py"
 INNER_SCRIPT_B2: Final[str] = "\
 9f596fb81d6b422fc2a53d9bde907f90daca814f9fd6107169dea8ed0e01e5740fbe22eb75dfc463a7762a64fd189fd3eb0799edfece8470ea566d50d68eade6"
-DEFAULT_CONF_PATH: Final[str] = "/etc/run0edit/editor.conf"
+DEFAULT_CONF_PATH: Final[str] = "@SYSCONFDIR@/run0edit/editor.conf"
 
 SYSTEM_CALL_DENY: Final[list[str]] = [
     "@aio",

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright 2026 run0edit authors (https://github.com/HastD/run0edit)
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+fs = import('fs')
+fs.copyfile('__init__.py')
+fs.copyfile('test_run0edit_common.py')
+fs.copyfile('test_run0edit_inner.py')
+fs.copyfile('test_run0edit_main.py')
+
+if get_option('unit-tests').enabled()
+    coverage = find_program('coverage')
+    test(
+        'unit-test',
+        coverage,
+        args: ['run', '-m', 'unittest'],
+        is_parallel: false,
+    )
+
+    test(
+        'unit-test-coverage',
+        coverage,
+        args: ['report', '-m', '--skip-empty', '--fail-under=100'],
+        is_parallel: false,
+    )
+endif


### PR DESCRIPTION
Meson is used for both creating the file tree to be installed and running tests. This simplifies packaging and installation.

Also switch to Ty (from MyPy) as the type-checker, and remove the ShellCheck linter workflow (the only shell scripts in the repo are basically trivial).