### PR TITLE
docs: add man page installed with the package

### DIFF
--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
-          dnf install -y meson nodejs python3 python3-coverage python3-devel \
+          dnf install -y meson nodejs pandoc-cli python3 python3-coverage python3-devel \
             rpmdevtools rpmlint ruff ty
           rpmdev-setuptree
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright 2025-2026 run0edit authors (https://github.com/HastD/run0edit)
+# SPDX-FileCopyrightText: (c) 2025-2026 run0edit authors <https://github.com/HastD/run0edit>
 #
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
@@ -38,7 +38,7 @@ jobs:
         run: |
           python3 -m pip install --upgrade pip
           pip install coverage meson ruff ty
-          sudo apt install just
+          sudo apt install just pandoc
 
       - name: Run tests
         run: |
@@ -61,6 +61,7 @@ jobs:
         run: |
           python3 -m pip install --upgrade pip
           pip install meson
+          sudo apt install pandoc
 
       - name: Set up passwordless authentication
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
   ([#93](https://github.com/HastD/run0edit/pull/93))
 - Switch to using Meson build system.
   ([#94](https://github.com/HastD/run0edit/pull/94))
+- Add man page.
+  ([#96](https://github.com/HastD/run0edit/pull/96))
 
 ## [v0.5.9] - 2026-05-06
 

--- a/Justfile
+++ b/Justfile
@@ -16,3 +16,6 @@ clean:
 
 test: build
     meson test -C build --verbose
+
+manpage: build
+    man -l build/docs/run0edit.1

--- a/README.md
+++ b/README.md
@@ -17,10 +17,9 @@ opened in an unprivileged editor; if modified, the edited file contents are
 copied back to the original location when the editor is closed.
 
 If the editor exits with an abnormal status code or copying the data back to the
-original location fails, then the temporary file will be left in the `/tmp`
-directory. The name of the temporary file is derived from the name of the
-original file, with a randomly generated suffix to avoid conflicts with existing
-files.
+original location fails, then the temporary file will be left in a directory of
+the form `/tmp/run0edit-*` (where `*` is replaced with a randomly generated
+suffix).
 
 The choice of editor can be customized by writing the path to a text editor (for
 example, `/usr/bin/vim`) to one of the following (listed in order of priority):

--- a/docs/meson.build
+++ b/docs/meson.build
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: (c) 2026 run0edit authors <https://github.com/HastD/run0edit>
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+
+pandoc = find_program('pandoc')
+
+md_manpage = configure_file(
+    input: 'run0edit.1.md.in',
+    output: 'run0edit.1.md',
+    configuration: conf_data,
+)
+
+custom_target(
+    'manpage',
+    input: md_manpage,
+    output: 'run0edit.1',
+    command: [
+        pandoc,
+        '-s',
+        '-f', 'markdown-smart',
+        '-t', 'man',
+        '-o', '@OUTPUT@',
+        '@INPUT@',
+    ],
+    build_by_default: true,
+    install: true,
+    install_dir: mandir / 'man1',
+)

--- a/docs/run0edit.1.md.in
+++ b/docs/run0edit.1.md.in
@@ -1,0 +1,92 @@
+<!--
+SPDX-FileCopyrightText: (c) 2026 run0edit authors <https://github.com/HastD/run0edit>
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+-->
+
+---
+title: run0edit
+section: 1
+header: run0edit user manual
+footer: run0edit @VERSION@
+date: 2026-07-05
+---
+
+# NAME
+
+run0edit - edit a file as root
+
+# SYNOPSIS
+
+run0edit [--editor EDITOR] [--background COLOR] [--no-prompt] FILE [FILES...]
+
+# DESCRIPTION
+
+**run0edit** allows a permitted user to edit a file as root, similar to
+**sudoedit** but using **run0** instead of **sudo** as the underlying privilege
+elevation mechanism.
+
+The target file (if it already exists) is copied to a temporary location and
+opened in an unprivileged editor; if modified, the edited file contents are
+copied back to the original location when the editor is closed.
+
+If the editor exits with an abnormal status code or copying the data back to the
+original location fails, then the temporary file will be left in a directory of
+the form **/tmp/run0edit-\*** (where **\*** is replaced with a randomly
+generated suffix).
+
+**run0edit** can also be used to edit files with the immutable attribute set.
+This works as follows:
+
+* The user edits the file as usual and exits the editor;
+* The immutable attribute is removed from the target file;
+* The changes are applied to the file;
+* The immutable attribute is immediately reapplied.
+
+# OPTIONS
+
+**--editor EDITOR**
+: Path to executable to be used as a text editor. The file name will be passed
+  as the first argument to the editor.
+
+**--background COLOR**
+: ANSI color to be set as the background color. Set as an empty string to
+  disable changing the background color. This option is passed on to **run0**.
+
+**--no-prompt**
+: Don't prompt for confirmation before editing a file with the immutable
+  attribute set.
+
+# ENVIRONMENT
+
+**VISUAL**, **EDITOR**
+: These environment variables are read for the default text editor if the
+  **--editor** argument is not used and there is no editor configured in
+  **editor.conf** (see **FILES** section below).
+: **VISUAL** has higher priority than **EDITOR**.
+
+# FILES
+
+**@SYSCONFDIR@/run0edit/editor.conf**
+: Global configuration file for the default editor used by **run0edit**. The
+  first line in this file that is not blank and does not begin with **#**
+  is interpreted as an absolute path to the editor executable.
+: If there is no such line, the file is ignored. If the path is not absolute or
+  does not point to an executable file, **run0edit** will give an error message
+  unless the **--editor** option is used.
+
+# EXIT STATUS
+
+On success, 0 is returned.
+
+If there is a usage error (for example, invalid arguments), 2 is returned.
+
+If another error occurs, 1 is returned.
+
+# BUGS
+
+Submit bug reports online at: <https://github.com/HastD/run0edit/issues>
+
+# SEE ALSO
+
+**run0(1)**, **sudoedit(8)**

--- a/meson.build
+++ b/meson.build
@@ -15,6 +15,7 @@ prefixdir = get_option('prefix')
 bindir = get_option('bindir')
 libexecdir = prefixdir / get_option('libexecdir')
 datadir = prefixdir / get_option('datadir')
+mandir = prefixdir / get_option('mandir')
 sysconfdir = get_option('sysconfdir')
 
 conf_data = configuration_data()
@@ -52,6 +53,7 @@ fs.copyfile('pyproject.toml')
 fs.copyfile('run0edit-local')
 
 subdir('data')
+subdir('docs')
 subdir('test')
 subdir('integration-test')
 

--- a/rpm/run0edit.spec
+++ b/rpm/run0edit.spec
@@ -13,6 +13,7 @@ Source0:        https://github.com/HastD/%{name}/archive/refs/tags/v%{version}.t
 
 BuildArch:      noarch
 BuildRequires:  meson
+BuildRequires:  pandoc
 BuildRequires:  python3-coverage
 BuildRequires:  python3-devel >= 3.10
 BuildRequires:  ruff
@@ -45,6 +46,7 @@ copied back to the original location when the editor is closed.
 %{_libexecdir}/%{name}
 %config(noreplace) %{_sysconfdir}/%{name}
 %license %{_defaultlicensedir}/%{name}
+%{_mandir}/man1/%{name}.1*
 
 %changelog
 * Wed May 06 2026 Daniel Hast <hast.daniel@protonmail.com> - v0.5.9

--- a/run0edit_main.py.in
+++ b/run0edit_main.py.in
@@ -441,7 +441,7 @@ def parse_arguments() -> argparse.Namespace:
     description = "run0edit allows a permitted user to edit a file as root."
     epilog = f"""\
     The default choice of text editor may be configured at {DEFAULT_CONF_PATH},
-    or by setting the VISUAL or EDITOR environment variables."
+    or by setting the VISUAL or EDITOR environment variables.
     """
     parser = argparse.ArgumentParser(prog="run0edit", description=description, epilog=epilog)
     parser.add_argument("-v", "--version", action="version", version=f"run0edit {__version__}")


### PR DESCRIPTION
The man page is converted from a Markdown file using Pandoc.

Also fixed a typo in the help message for run0edit.