### PR TITLE
feat: revise execution model; release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 
 # Changelog
 
+## [v0.6.0] - 2026-08-22
+
+This version contains two significant changes to run0edit's execution model.
+([#106](https://github.com/HastD/run0edit/pull/106))
+
+First, the privileged inner script is now executed by replacing the main
+process, rather than spawning it as a subprocess. This means the parent process
+of the process that triggers the Polkit authorization check will be the user's
+shell, allowing run0edit to work properly with Polkit's authentication caching
+mechanism (`AUTH_KEEP`).
+
+Second, the editor is now executed from within the privileged script using
+`runuser` instead of a second call to `run0`. This has several implications:
+
+- The privileged script now sets the UID and GID for the editor process itself,
+  rather than delegating to systemd via DBus. In particular, the privileged
+  script no longer needs DBus access at all, so we can block that sandbox escape
+  route entirely.
+- The systemd sandboxing options now apply to the editor session as well, not
+  just to the portion of the script that runs as root. This requires various
+  changes to the systemd sandboxing options.
+- A small visual difference: The editor's default background color will now
+  match the dark red background used by `run0` as the default for root.
+
 ## [v0.5.10] - 2026-07-05
 
 ### User-facing changes
@@ -200,6 +224,7 @@ Rewrote script in Python. ([#1](https://github.com/HastD/run0edit/pull/1))
 
 - Initial release.
 
+[v0.6.0]: https://github.com/HastD/run0edit/compare/v0.5.10...v0.6.0
 [v0.5.10]: https://github.com/HastD/run0edit/compare/v0.5.9...v0.5.10
 [v0.5.9]: https://github.com/HastD/run0edit/compare/v0.5.8...v0.5.9
 [v0.5.8]: https://github.com/HastD/run0edit/compare/v0.5.7...v0.5.8

--- a/Justfile
+++ b/Justfile
@@ -8,7 +8,7 @@
 
 build:
     mkdir -p build
-    meson setup build -Dprefix=/usr
+    meson setup --reconfigure build -Dprefix=/usr
     meson compile -C build
 
 clean:

--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ example, `/usr/bin/vim`) to one of the following (listed in order of priority):
 If none of these point to an executable file, `run0edit` will default to using
 `nano` or `vi`.
 
-> Note: Editors that make use of JIT compilation (such as Neovim built with
-> LuaJIT) might not work: as a security measure, `run0edit` makes use of systemd
+> [!NOTE]
+> Editors that make use of JIT compilation (such as Neovim built with LuaJIT)
+> might not work: as a security measure, `run0edit` makes use of systemd
 > sandboxing settings, including `MemoryDenyWriteExecute`, which prevents code
 > generated dynamically at runtime from being executed.
 

--- a/integration-test/integration_tests.py
+++ b/integration-test/integration_tests.py
@@ -11,7 +11,8 @@ with passwordless run0.
 
 import os
 import secrets
-import subprocess  # nosec
+import subprocess
+import sys
 import tempfile
 import unittest
 from typing import Final
@@ -30,12 +31,12 @@ def run0edit(
     *args: str, editor: str = EDITOR, check: bool = True
 ) -> subprocess.CompletedProcess[str]:
     """Call run0edit with the provided arguments"""
-    return subprocess.run(
-        ["./run0edit-local", f"--editor={editor}", "--debug", "--no-prompt", "--", *args],
-        check=check,
-        capture_output=True,
-        text=True,
-    )  # nosec
+    cmd_args = ["./run0edit-local", f"--editor={editor}", "--debug", "--no-prompt", "--", *args]
+    result = subprocess.run(cmd_args, check=False, capture_output=True, text=True)
+    if check and result.returncode != 0:
+        print(f"stdout:\n{result.stdout}\n\nstderr:\n{result.stderr}\n", file=sys.stderr)
+        raise subprocess.CalledProcessError(result.returncode, cmd_args)
+    return result
 
 
 def random_filename(length: int = 32) -> str:
@@ -71,12 +72,12 @@ class TestFile:
             check=True,
             capture_output=True,
             text=True,
-        )  # nosec
+        )
         self._path = result.stdout.strip()
         if mode is not None:
-            subprocess.run([RUN0, cmd("chmod"), f"{mode:o}", "--", self._path], check=True)  # nosec
+            subprocess.run([RUN0, cmd("chmod"), f"{mode:o}", "--", self._path], check=True)
         if immutable:
-            subprocess.run([RUN0, cmd("chattr"), "+i", "--", self._path], check=True)  # nosec
+            subprocess.run([RUN0, cmd("chattr"), "+i", "--", self._path], check=True)
 
     @property
     def path(self) -> str:
@@ -90,7 +91,7 @@ class TestFile:
             check=True,
             capture_output=True,
             text=True,
-        )  # nosec
+        )
         return "i" in result.stdout.strip().split(maxsplit=1)[0]
 
     def read(self) -> str:
@@ -100,15 +101,15 @@ class TestFile:
             check=True,
             capture_output=True,
             text=True,
-        )  # nosec
+        )
         return result.stdout
 
     def __del__(self):
         """Remove the file."""
         subprocess.run(
             [RUN0, cmd("chattr"), "-R", "-i", "--", self._path], check=False, capture_output=True
-        )  # nosec
-        subprocess.run([RUN0, cmd("rm"), "-rf", "--", self._path], check=False, capture_output=True)  # nosec
+        )
+        subprocess.run([RUN0, cmd("rm"), "-rf", "--", self._path], check=False, capture_output=True)
 
 
 class TestIntegration(unittest.TestCase):
@@ -198,9 +199,17 @@ class TestIntegration(unittest.TestCase):
     def test_read_only_filesystem(self):
         """Should give expected error if file is on read-only filesystem"""
         ro_mount_dir = tempfile.mkdtemp()
-        mount_ro = 'mount --bind -o ro "$1" "$2"'
         subprocess.run(
-            [RUN0, cmd("sh"), "-c", mount_ro, cmd("sh"), tempfile.gettempdir(), ro_mount_dir],
+            [
+                RUN0,
+                "--via-shell",
+                "mount",
+                "--bind",
+                "-o",
+                "ro",
+                tempfile.gettempdir(),
+                ro_mount_dir,
+            ],
             check=True,
         )
         file = TestFile(directory=ro_mount_dir, create=False)

--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,7 @@
 
 project(
     'run0edit',
-    version: '0.5.10',
+    version: '0.6.0',
     meson_version: '>= 1.3.0',
     license: 'Apache-2.0 OR MIT',
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ select = [
 
 ignore = [
     "S603", # subprocess-without-shell-equals-true
+    "S606", # start-process-with-no-shell
     "SIM105", # suppressible-exception
     "N806", # non-lowercase-variable-in-function
 ]

--- a/rpm/run0edit.spec
+++ b/rpm/run0edit.spec
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 Name:           run0edit
-Version:        0.5.10
-Release:        2
+Version:        0.6.0
+Release:        1
 Summary:        run0edit allows a permitted user to edit a file as root.
 
 License:        Apache-2.0 OR MIT
@@ -17,6 +17,7 @@ BuildRequires:  pandoc
 BuildRequires:  python3-devel >= 3.10
 Requires:       python3 >= 3.10
 Requires:       systemd >= 256
+Requires:       util-linux
 Recommends:     e2fsprogs
 
 %description
@@ -46,6 +47,12 @@ copied back to the original location when the editor is closed.
 %{_mandir}/man1/%{name}.1*
 
 %changelog
+* Sat Aug 22 2026 Daniel Hast <hast.daniel@protonmail.com> - v0.6.0
+- Use execv to replace main process with privileged process. This makes run0edit
+  work properly with Polkit's authentication caching.
+- Use `runuser` to run editor as user in privileged script, avoiding the need
+  for nested DBus calls.
+
 * Sun Jul 05 2026 Daniel Hast <hast.daniel@protonmail.com> - v0.5.10
 - Switch to using Meson build system.
 - Add man page.

--- a/run0edit_inner.py
+++ b/run0edit_inner.py
@@ -78,7 +78,7 @@ def readonly_filesystem(path: str) -> bool | None:
 
 def find_command(command: str) -> str:
     """Search for command using a default path."""
-    cmd_path = shutil.which(command, path="/usr/bin:/bin")
+    cmd_path = shutil.which(command, path="/usr/bin:/bin:/usr/sbin:/sbin")
     if cmd_path is None:
         raise CommandNotFoundError(command)
     return cmd_path
@@ -290,17 +290,14 @@ def handle_copy_to_original(
         raise
 
 
-def run_editor(*, uid: int, editor: str, path: str, bgcolor: str | None = None) -> None:
+def run_editor(*, user: str, editor: str, path: str) -> None:
     """Run the editor as the given UID to edit the file at the given path."""
-    sh = find_command("sh")
-    run0_args = ["run0", f"--user={uid}"]
-    if bgcolor is not None:
-        run0_args.append(f"--background={bgcolor}")
-    run0_args += ["--", sh, "-c", '"$1" "$2"', sh, editor, path]
     try:
-        run_command(*run0_args)
+        # We use a login shell here to ensure the unprivileged editor has the environment
+        # associated with a fresh shell session for that user.
+        run_command("runuser", "--pty", "-", user, "-c", 'exec "$0" "$1"', editor, path)
     except CommandNotFoundError as e:
-        print("run0edit: failed to call run0 to start editor")
+        print("run0edit: failed to call runuser to start editor")
         raise EditTempFileError from e
     except SubprocessError as e:
         print(f"run0edit: failed to edit temporary file at {path}")
@@ -311,10 +308,9 @@ def run(
     original_file: str,
     temp_file: str,
     editor: str,
-    uid: int,
+    user: str,
     *,
     prompt_immutable: bool = True,
-    bgcolor: str | None = None,
 ) -> None:
     """
     Copy file to temp file, run editor, and copy temp file back to target file.
@@ -339,7 +335,7 @@ def run(
             raise
 
     # Attempt to edit the temp file as the original user.
-    run_editor(uid=uid, editor=editor, path=temp_file, bgcolor=bgcolor)
+    run_editor(user=user, editor=editor, path=temp_file)
 
     handle_copy_to_original(
         original_file, temp_file, original_file_exists=original_file_exists, immutable=immutable
@@ -350,46 +346,50 @@ class InvalidArgumentsError(Exception):
     """Arguments to script are invalid."""
 
 
-def parse_args(args: Sequence[str]) -> tuple[str, str, str, str | None]:
+def parse_args(args: Sequence[str]) -> tuple[str, str, str]:
     """Parse command-line arguments, raising error if too few or too many."""
-    EXPECTED_MIN_ARGS = 3
-    EXPECTED_MAX_ARGS = 4
-    if len(args) < EXPECTED_MIN_ARGS:
+    EXPECTED_ARGS = 3
+    if len(args) < EXPECTED_ARGS:
         print("run0edit_inner.py: Error: too few arguments")
         raise InvalidArgumentsError
-    if len(args) > EXPECTED_MAX_ARGS:
+    if len(args) > EXPECTED_ARGS:
         print("run0edit_inner.py: Error: too many arguments")
         raise InvalidArgumentsError
+    return args[0], args[1], args[2]
+
+
+def remove_temp_file(path: str, *, only_if_empty: bool = False) -> None:
+    """Delete the temporary file"""
+    if only_if_empty and os.path.getsize(path) > 0:
+        return
+    os.remove(path)
+    directory = os.path.dirname(path)
     try:
-        bgcolor = args[3]
-    except IndexError:
-        bgcolor = None
-    return args[0], args[1], args[2], bgcolor
+        os.rmdir(directory)
+    except OSError:
+        print(
+            f"run0edit: Warning: failed to remove temporary directory {directory}", file=sys.stderr
+        )
 
 
-def main(args: Sequence[str], *, uid: int | None = None) -> int:
+def main(args: Sequence[str], *, user: str | None = None) -> int:
     """Main function."""
     try:
-        original_file, temp_file, editor, bgcolor = parse_args(args)
+        original_file, temp_file, editor = parse_args(args)
     except InvalidArgumentsError:
         return 2
-    if uid is None:
-        uid = int(os.environ["SUDO_UID"])
+    if user is None:
+        user = os.environ["SUDO_USER"]
     debug = os.environ.get("RUN0EDIT_DEBUG") == "1"
     prompt_immutable = os.environ.get("RUN0EDIT_NO_PROMPT") != "1"
     try:
-        run(
-            original_file,
-            temp_file,
-            editor,
-            uid,
-            prompt_immutable=prompt_immutable,
-            bgcolor=bgcolor,
-        )
+        run(original_file, temp_file, editor, user, prompt_immutable=prompt_immutable)
     except Run0editError:
+        remove_temp_file(temp_file, only_if_empty=True)
         if debug:
             raise
         return 1
+    remove_temp_file(temp_file)
     return 0
 
 

--- a/run0edit_main.py.in
+++ b/run0edit_main.py.in
@@ -17,7 +17,6 @@ import hashlib
 import os
 import shutil
 import stat
-import subprocess  # nosec
 import sys
 import tempfile
 import textwrap
@@ -28,27 +27,37 @@ from typing import Final
 __version__: Final[str] = "@VERSION@"
 INNER_SCRIPT_PATH: Final[str] = "@LIBEXECDIR@/run0edit/run0edit_inner.py"
 INNER_SCRIPT_B2: Final[str] = "\
-9f596fb81d6b422fc2a53d9bde907f90daca814f9fd6107169dea8ed0e01e5740fbe22eb75dfc463a7762a64fd189fd3eb0799edfece8470ea566d50d68eade6"
+7d215d913fbc27ace618e1354a6dadcc8277a3eb77dfa38a243d6a5e76e0e350afd5143a0b6bb34059b089cef19a957340cb2c1af4040c0ea489af31875bfb05"
 DEFAULT_CONF_PATH: Final[str] = "@SYSCONFDIR@/run0edit/editor.conf"
+
+CAPABILITY_BOUNDING_SET: Final[list[str]] = [
+    "CAP_CHOWN",
+    "CAP_DAC_OVERRIDE",
+    "CAP_FOWNER",
+    "CAP_LINUX_IMMUTABLE",
+    "CAP_SETGID",
+    "CAP_SETUID",
+]
 
 SYSTEM_CALL_DENY: Final[list[str]] = [
     "@aio",
-    "@chown",
+    "@clock",
     "@keyring",
     "@memlock",
+    "@module",
     "@mount",
-    "@privileged",
-    "@resources",
-    "@setuid",
+    "@raw-io",
+    "@reboot",
+    "@swap",
     "memfd_create",
 ]
 
 SYSTEMD_SANDBOX_PROPERTIES: Final[list[str]] = [
-    "CapabilityBoundingSet=CAP_DAC_OVERRIDE CAP_FOWNER CAP_LINUX_IMMUTABLE",
+    f"CapabilityBoundingSet={' '.join(CAPABILITY_BOUNDING_SET)}",
     "DevicePolicy=closed",
+    "InaccessiblePaths=/run/dbus /run/user",
     "LockPersonality=yes",
     "MemoryDenyWriteExecute=yes",
-    "NoNewPrivileges=yes",
     "PrivateDevices=yes",
     "PrivateIPC=yes",
     "PrivateNetwork=yes",
@@ -60,7 +69,6 @@ SYSTEMD_SANDBOX_PROPERTIES: Final[list[str]] = [
     "ProtectKernelModules=yes",
     "ProtectKernelTunables=yes",
     "ProtectProc=noaccess",
-    "ReadOnlyPaths=/",
     "RestrictAddressFamilies=AF_UNIX",
     "RestrictNamespaces=yes",
     "RestrictRealtime=yes",
@@ -96,7 +104,7 @@ class CommandNotFoundError(Exception):
 
 def find_command(command: str) -> str:
     """Search for command using a default path."""
-    cmd_path = shutil.which(command, path="/usr/bin:/bin")
+    cmd_path = shutil.which(command, path="/usr/bin:/bin:/usr/sbin:/sbin")
     if cmd_path is None:
         raise CommandNotFoundError(command)
     return cmd_path
@@ -279,19 +287,13 @@ class TempFile:
 
     def remove(self, *, only_if_empty: bool = False) -> None:
         """Delete the temporary file"""
-        if not only_if_empty or os.path.getsize(self.path) == 0:
-            os.remove(self.path)
+        if only_if_empty and os.path.getsize(self.path) > 0:
+            return
+        os.remove(self.path)
+        try:
             os.rmdir(self.directory)
-
-
-def escape_path(path: str) -> str:
-    """Escape a path for use in a systemd property string."""
-    return path.replace("\\", "\\\\").replace('"', '\\"')
-
-
-def sandbox_path(path: str) -> str:
-    """Get the path to be passed to ReadWritePaths"""
-    return path if os.path.exists(path) else os.path.dirname(path)
+        except OSError:
+            print_err(f"Warning: failed to remove temporary directory {self.directory}")
 
 
 @dataclasses.dataclass
@@ -328,14 +330,10 @@ def build_run0_arguments(
 ) -> Run0Arguments:
     """Construct the arguments to be passed to run0."""
     python_cmd = find_command("python3")
-    rw_path = sandbox_path(path)
-    rw_path_prop = f'ReadWritePaths="{escape_path(rw_path)}" "{escape_path(temp_path)}"'
-    systemd_properties = [*SYSTEMD_SANDBOX_PROPERTIES, rw_path_prop]
     extra_options = []
     python_args = [INNER_SCRIPT_PATH, path, temp_path, editor]
     if bgcolor is not None:
         extra_options.append(f"--background={bgcolor}")
-        python_args.append(bgcolor)
     setenv = {}
     if debug:
         setenv["RUN0EDIT_DEBUG"] = "1"
@@ -343,7 +341,7 @@ def build_run0_arguments(
         setenv["RUN0EDIT_NO_PROMPT"] = "1"
     return Run0Arguments(
         description=f'run0edit "{path}"',
-        systemd_properties=systemd_properties,
+        systemd_properties=SYSTEMD_SANDBOX_PROPERTIES,
         command=python_cmd,
         command_args=python_args,
         extra_options=extra_options,
@@ -403,28 +401,14 @@ def run(
     run0_args = build_run0_arguments(
         path, temp_file.path, editor, bgcolor=bgcolor, debug=debug, no_prompt=no_prompt
     )
-    env = os.environ.copy()
-    if os.geteuid() == 0:
-        env["SYSTEMD_ADJUST_TERMINAL_TITLE"] = "false"
-    process = subprocess.run(run0_args.argument_list(), env=env, check=False)  # nosec
-    match process.returncode:
-        case 0:
-            temp_file.remove()
-            return 0
-        case 226:
-            # If directory does not exist, namespace creation will fail, causing
-            # run0 to fail with exit status 226:
-            # https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html
-            # This can also occur if the path is privileged (such as /etc/shadow)
-            # and SELinux is enabled and blocks systemd from mounting the namespace.
-            print_err(
-                f"No such directory {os.path.dirname(path)}, or path is in a privileged location."
-            )
-            temp_file.remove()
-            return 1
-        case _:
-            temp_file.remove(only_if_empty=True)
-            return process.returncode
+    argv = run0_args.argument_list()
+    try:
+        return os.execv(argv[0], argv)
+    except OSError:
+        print_err("Warning: execution of run0 failed")
+        return 1
+    finally:
+        temp_file.remove()
 
 
 def ansi_color(color: str) -> str:
@@ -488,7 +472,7 @@ def main() -> int:
     if not validate_inner_script():
         print_err(f"""
             ERROR: Inner script was not found at {INNER_SCRIPT_PATH} or did not
-            have expected SHA-256 hash!
+            have expected BLAKE2 hash!
         """)
         return 1
     try:

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -44,4 +44,7 @@ def remove_test_dir(path: str) -> None:
     """Remove the temporary directory and all its contents."""
     if not os.path.basename(path).startswith(TEMP_FILE_PREFIX):  # pragma: no cover
         raise ValueError("invalid directory name - this doesn't look like a test directory")
-    shutil.rmtree(path)
+    try:
+        shutil.rmtree(path)
+    except FileNotFoundError:
+        pass

--- a/test/test_run0edit_common.py
+++ b/test/test_run0edit_common.py
@@ -65,4 +65,6 @@ class TestFindCommand(unittest.TestCase):
         for mod in (run0edit_inner, run0edit_main):
             with mock.patch("shutil.which") as mock_which:
                 mod.find_command(cmd)
-                self.assertEqual(mock_which.call_args_list, [((cmd,), {"path": "/usr/bin:/bin"})])
+                self.assertEqual(
+                    mock_which.call_args_list, [((cmd,), {"path": "/usr/bin:/bin:/usr/sbin:/sbin"})]
+                )

--- a/test/test_run0edit_inner.py
+++ b/test/test_run0edit_inner.py
@@ -9,6 +9,7 @@
 import io
 import os
 import unittest
+from pathlib import Path
 from unittest import mock
 
 import run0edit_inner as inner
@@ -538,51 +539,27 @@ class TestRunEditor(unittest.TestCase):
     @mock.patch("run0edit_inner.find_command")
     def test_check_args(self, mock_find_cmd, mock_run_cmd, mock_stdout):
         """Should pass correct arguments to run_command"""
+        user = mock.sentinel.user
         editor = mock.sentinel.editor
         path = mock.sentinel.path
         mock_find_cmd.side_effect = lambda cmd: f"/bin/{cmd}"
-        inner.run_editor(uid=42, editor=editor, path=path)
+        inner.run_editor(user=user, editor=editor, path=path)
         self.assertEqual(
             mock_run_cmd.call_args.args,
-            ("run0", "--user=42", "--", "/bin/sh", "-c", '"$1" "$2"', "/bin/sh", editor, path),
-        )
-        self.assertEqual(mock_stdout.getvalue(), "")
-
-    @mock.patch("run0edit_inner.find_command")
-    def test_check_args_with_bgcolor(self, mock_find_cmd, mock_run_cmd, mock_stdout):
-        """Should pass correct arguments to run_command"""
-        editor = mock.sentinel.editor
-        path = mock.sentinel.path
-        bgcolor = "bgcolor"
-        mock_find_cmd.side_effect = lambda cmd: f"/bin/{cmd}"
-        inner.run_editor(uid=42, editor=editor, path=path, bgcolor=bgcolor)
-        self.assertEqual(
-            mock_run_cmd.call_args.args,
-            (
-                "run0",
-                "--user=42",
-                "--background=bgcolor",
-                "--",
-                "/bin/sh",
-                "-c",
-                '"$1" "$2"',
-                "/bin/sh",
-                editor,
-                path,
-            ),
+            ("runuser", "--pty", "-", user, "-c", 'exec "$0" "$1"', editor, path),
         )
         self.assertEqual(mock_stdout.getvalue(), "")
 
     def test_error_messages(self, mock_run_cmd, mock_stdout):
         """Should print appropriate error messages and raise EditTempFileError"""
         errors = {
-            inner.CommandNotFoundError: "failed to call run0 to start editor",
+            inner.CommandNotFoundError: "failed to call runuser to start editor",
             inner.SubprocessError: "failed to edit temporary file",
         }
         mock_run_cmd.side_effect = iter(errors)
         for message in errors.values():
             with self.assertRaises(inner.EditTempFileError):
-                inner.run_editor(uid=42, editor="butterfly", path="some/path")
+                inner.run_editor(user="username", editor="butterfly", path="some/path")
             self.assertIn(message, mock_stdout.getvalue())
             mock_stdout.truncate(0)
             mock_stdout.seek(0)
@@ -611,7 +588,7 @@ class TestRun(TestCaseWithFiles):
         m_realpath.return_value = s.realpath
         m_exists.return_value = True
         m_check_ro.return_value = s.immutable
-        inner.run(s.filename, s.temp_filename, s.editor, s.uid, bgcolor=s.bgcolor)
+        inner.run(s.filename, s.temp_filename, s.editor, s.user)
         self.assertEqual(m_realpath.call_args.args, (s.filename,))
         self.assertEqual(m_exists.call_args.args, (s.realpath,))
         self.assertEqual(
@@ -621,7 +598,7 @@ class TestRun(TestCaseWithFiles):
         self.assertEqual(m_copy_file.call_args, ((s.realpath, s.temp_filename), {"create": False}))
         self.assertEqual(
             m_run_editor.call_args,
-            ((), {"uid": s.uid, "editor": s.editor, "path": s.temp_filename, "bgcolor": s.bgcolor}),
+            ((), {"user": s.user, "editor": s.editor, "path": s.temp_filename}),
         )
         self.assertEqual(
             m_copy_orig.call_args,
@@ -637,7 +614,7 @@ class TestRun(TestCaseWithFiles):
         """Should print message and raise FileCopyError if copy to temp fails"""
         mock_copy_file.side_effect = inner.FileCopyError
         with self.assertRaises(inner.FileCopyError):
-            inner.run(self.filename, self.temp_filename, "editor", 42)
+            inner.run(self.filename, self.temp_filename, "editor", "username")
         self.assertFalse(mock_run_editor.called)
         self.assertRegex(mock_stdout.getvalue(), " failed to copy .* to temporary file ")
 
@@ -645,7 +622,7 @@ class TestRun(TestCaseWithFiles):
         """Should copy edited tempfile contents to target file"""
         text = b"Lorum ipsum dolor sit amet"
         mock_run_editor.side_effect = lambda **_: self.edit_temp_file(text)
-        inner.run(self.filename, self.temp_filename, "editor", 42)
+        inner.run(self.filename, self.temp_filename, "editor", "username")
         with open(self.filename, "rb") as f:
             self.assertEqual(f.read(), text)
         self.assertEqual(mock_stdout.getvalue(), "")
@@ -653,7 +630,7 @@ class TestRun(TestCaseWithFiles):
     @mock.patch("run0edit_inner.copy_to_original")
     def test_edit_unchanged(self, mock_copy_to_orig, mock_run_editor, mock_stdout):
         """Should not copy unmodified tempfile contents to target file"""
-        inner.run(self.filename, self.temp_filename, "editor", 42)
+        inner.run(self.filename, self.temp_filename, "editor", "username")
         with open(self.filename, "rb") as f:
             self.assertEqual(f.read(), self.file_contents)
         self.assertTrue(mock_run_editor.called)
@@ -665,7 +642,7 @@ class TestRun(TestCaseWithFiles):
         """Should not try copying nonexistent file to temp file"""
         mock_run_editor.side_effect = Exception("mock run editor")
         with self.assertRaisesRegex(Exception, "mock run editor"):
-            inner.run(self.new_filename, self.temp_filename, "editor", 42)
+            inner.run(self.new_filename, self.temp_filename, "editor", "username")
         self.assertFalse(mock_copy_file.called)
         self.assertEqual(mock_stdout.getvalue(), "")
 
@@ -673,7 +650,7 @@ class TestRun(TestCaseWithFiles):
         """Should copy edited tempfile contents to new file"""
         text = b"Lorum ipsum dolor sit amet"
         mock_run_editor.side_effect = lambda **_: self.edit_temp_file(text)
-        inner.run(self.new_filename, self.temp_filename, "editor", 42)
+        inner.run(self.new_filename, self.temp_filename, "editor", "username")
         with open(self.new_filename, "rb") as f:
             self.assertEqual(f.read(), text)
         self.assertEqual(mock_stdout.getvalue(), "")
@@ -683,7 +660,7 @@ class TestRun(TestCaseWithFiles):
         """Should not create empty new file"""
         with open(self.temp_filename, "wb"):
             pass
-        inner.run(self.new_filename, self.temp_filename, "editor", 42)
+        inner.run(self.new_filename, self.temp_filename, "editor", "username")
         self.assertFalse(os.path.exists(self.new_filename))
         self.assertTrue(mock_run_editor.called)
         self.assertFalse(mock_copy_to_orig.called)
@@ -699,7 +676,7 @@ class TestRun(TestCaseWithFiles):
             mock_ask_imm.return_value = False
             mock_is_imm.return_value = True
             mock_ro_fs.return_value = False
-            inner.run("/proc/version", self.temp_filename, "editor", 42)
+            inner.run("/proc/version", self.temp_filename, "editor", "username")
         self.assertFalse(mock_run_editor.called)
         self.assertIn("declined to remove immutable attribute", mock_stdout.getvalue())
 
@@ -708,15 +685,10 @@ class TestRun(TestCaseWithFiles):
 class TestParseArgs(unittest.TestCase):
     """Tests for parse_args"""
 
-    ARGS = (mock.sentinel.a0, mock.sentinel.a1, mock.sentinel.a2, mock.sentinel.a3)
+    ARGS = (mock.sentinel.a0, mock.sentinel.a1, mock.sentinel.a2)
 
-    def test_three_args(self, mock_stdout):
+    def test_parse_args(self, mock_stdout):
         """Should return three provided arguments plus None"""
-        self.assertEqual(inner.parse_args(self.ARGS[:3]), (*self.ARGS[:3], None))
-        self.assertEqual(mock_stdout.getvalue(), "")
-
-    def test_four_args(self, mock_stdout):
-        """Should return four provided arguments"""
         self.assertEqual(inner.parse_args(self.ARGS), self.ARGS)
         self.assertEqual(mock_stdout.getvalue(), "")
 
@@ -733,52 +705,114 @@ class TestParseArgs(unittest.TestCase):
         self.assertEqual(mock_stdout.getvalue(), "run0edit_inner.py: Error: too many arguments\n")
 
 
+class TestRemoveTempFile(unittest.TestCase):
+    """Tests for remove_temp_file"""
+
+    def setUp(self):
+        """Make test directory and test file"""
+        self.dir = new_test_dir()
+        self.file = f"{self.dir}/temp_file"
+        Path(self.file).touch(mode=0o600)
+
+    def tearDown(self):
+        """Remove test directory and test file"""
+        remove_test_dir(self.dir)
+
+    def test_removes_temp_file_and_dir(self):
+        """Should remove test file and test directory."""
+        self.assertTrue(os.path.isdir(self.dir))
+        self.assertTrue(os.path.isfile(self.file))
+        inner.remove_temp_file(self.file)
+        self.assertFalse(os.path.exists(self.dir))
+        self.assertFalse(os.path.exists(self.file))
+
+    def test_removes_empty_file(self):
+        """Should remove empty temp file if only_if_empty is set"""
+        self.assertTrue(os.path.isdir(self.dir))
+        self.assertTrue(os.path.isfile(self.file))
+        inner.remove_temp_file(self.file, only_if_empty=True)
+        self.assertFalse(os.path.exists(self.dir))
+        self.assertFalse(os.path.exists(self.file))
+
+    def test_preserves_nonempty_file(self):
+        """Should not remove non-empty temp file if only_if_empty is set"""
+        self.assertTrue(os.path.isdir(self.dir))
+        self.assertTrue(os.path.isfile(self.file))
+        Path(self.file).write_text("asdf")
+        inner.remove_temp_file(self.file, only_if_empty=True)
+        self.assertTrue(os.path.exists(self.dir))
+        self.assertTrue(os.path.exists(self.file))
+
+    @mock.patch("sys.stderr", new_callable=io.StringIO)
+    def test_preserves_directory_if_unexpected_file(self, mock_stderr):
+        """Should remove file but not directory if unexpected extra file is present"""
+        unexpected_file = Path(self.dir) / "unexpected"
+        unexpected_file.touch(mode=0o600)
+        self.assertTrue(os.path.isdir(self.dir))
+        self.assertTrue(os.path.isfile(self.file))
+        self.assertTrue(os.path.isfile(unexpected_file))
+        inner.remove_temp_file(self.file)
+        self.assertTrue(os.path.exists(self.dir))
+        self.assertFalse(os.path.exists(self.file))
+        self.assertTrue(os.path.isfile(unexpected_file))
+        self.assertIn(
+            "run0edit: Warning: failed to remove temporary directory", mock_stderr.getvalue()
+        )
+
+
+@mock.patch("run0edit_inner.remove_temp_file")
 @mock.patch("run0edit_inner.run")
-@mock.patch("os.environ", new={"SUDO_UID": 42})
+@mock.patch("os.environ", new={"SUDO_USER": "username"})
 class TestMain(unittest.TestCase):
     """Tests for main"""
 
-    ARGS = (mock.sentinel.a0, mock.sentinel.a1, mock.sentinel.a2, mock.sentinel.a3)
-    EXPECTED_ARGS = ((*ARGS[:3], 42), {"bgcolor": ARGS[3], "prompt_immutable": True})
+    ARGS = (mock.sentinel.a0, mock.sentinel.a1, mock.sentinel.a2)
+    EXPECTED_ARGS = ((*ARGS, "username"), {"prompt_immutable": True})
 
     @mock.patch("run0edit_inner.parse_args")
-    def test_parses_args(self, mock_parse_args, mock_run):
+    def test_parses_args(self, mock_parse_args, mock_run, mock_rm_temp):
         """Should parse arguments using parse_args"""
         mock_parse_args.return_value = self.ARGS
         inner.main(mock.sentinel.main_args)
         self.assertEqual(mock_parse_args.call_args, ((mock.sentinel.main_args,), {}))
         self.assertEqual(mock_run.call_args, self.EXPECTED_ARGS)
+        self.assertEqual(mock_rm_temp.call_args, ((self.ARGS[1],), {}))
 
     @mock.patch("run0edit_inner.parse_args")
-    def test_invalid_args(self, mock_parse_args, mock_run):
+    def test_invalid_args(self, mock_parse_args, mock_run, mock_rm_temp):
         """Should return 2 if parse_args raises InvalidArgumentsError"""
         mock_parse_args.side_effect = inner.InvalidArgumentsError
         self.assertEqual(inner.main(mock.sentinel.main_args), 2)
         self.assertFalse(mock_run.called)
+        self.assertFalse(mock_rm_temp.called)
 
-    def test_normal_run(self, mock_run):
+    def test_normal_run(self, mock_run, mock_rm_temp):
         """Should pass correct args to run and return 0"""
         self.assertEqual(inner.main(self.ARGS), 0)
         self.assertEqual(mock_run.call_args, self.EXPECTED_ARGS)
+        self.assertEqual(mock_rm_temp.call_args, ((self.ARGS[1],), {}))
 
-    def test_normal_run_with_uid(self, mock_run):
+    def test_normal_run_with_user(self, mock_run, mock_rm_temp):
         """Should pass correct args to run and return 0"""
-        self.assertEqual(inner.main(self.ARGS, uid=5), 0)
+        self.assertEqual(inner.main(self.ARGS, user="foo"), 0)
         self.assertEqual(
             mock_run.call_args,
-            ((*self.ARGS[:3], 5), {"bgcolor": self.ARGS[3], "prompt_immutable": True}),
+            ((*self.ARGS, "foo"), {"prompt_immutable": True}),
         )
+        self.assertEqual(mock_rm_temp.call_args, ((self.ARGS[1],), {}))
 
-    def test_failed_run(self, mock_run):
+    def test_failed_run(self, mock_run, mock_rm_temp):
         """Should pass correct args to run and return 1"""
         mock_run.side_effect = inner.Run0editError
         self.assertEqual(inner.main(self.ARGS), 1)
         self.assertEqual(mock_run.call_args, self.EXPECTED_ARGS)
+        self.assertEqual(mock_rm_temp.call_args, ((self.ARGS[1],), {"only_if_empty": True}))
 
     @mock.patch.dict("os.environ", {"RUN0EDIT_DEBUG": "1"})
-    def test_failed_run_debug(self, mock_run):
+    def test_failed_run_debug(self, mock_run, mock_rm_temp):
         """Should pass correct args to run and raise exception"""
         mock_run.side_effect = inner.Run0editError
         with self.assertRaises(inner.Run0editError):
             inner.main(self.ARGS)
         self.assertEqual(mock_run.call_args, self.EXPECTED_ARGS)
+        self.assertEqual(mock_rm_temp.call_args, ((self.ARGS[1],), {"only_if_empty": True}))

--- a/test/test_run0edit_main.py
+++ b/test/test_run0edit_main.py
@@ -11,6 +11,7 @@ import io
 import os
 import pathlib
 import re
+import shutil
 import unittest
 from collections.abc import Callable, Sequence
 from typing import Any
@@ -44,13 +45,13 @@ class TestGlobalConstants(unittest.TestCase):
 
     def test_system_call_deny(self):
         """SYSTEM_CALL_DENY should have expected number and format of items"""
-        self.assertEqual(len(run0edit.SYSTEM_CALL_DENY), 9)
+        self.assertEqual(len(run0edit.SYSTEM_CALL_DENY), 10)
         for item in run0edit.SYSTEM_CALL_DENY:
             self.assertRegex(item, r"^@?[a-zA-Z0-9_-]+$")
 
     def test_systemd_sandbox_properties(self):
         """SYSTEMD_SANDBOX_PROPERTIES should have expected number and format of items"""
-        self.assertEqual(len(run0edit.SYSTEMD_SANDBOX_PROPERTIES), 25)
+        self.assertEqual(len(run0edit.SYSTEMD_SANDBOX_PROPERTIES), 24)
         for prop in run0edit.SYSTEMD_SANDBOX_PROPERTIES:
             self.assertIsInstance(prop, str)
             self.assertIn("=", prop)
@@ -452,7 +453,7 @@ class TestTempFile(unittest.TestCase):
         """Clean up temp files"""
         for temp_file in (self.empty_file, self.non_empty_file):
             try:
-                temp_file.remove()
+                shutil.rmtree(temp_file.directory)
             except OSError:
                 pass
 
@@ -496,65 +497,16 @@ class TestTempFile(unittest.TestCase):
         self.non_empty_file.remove(only_if_empty=True)
         self.assertTrue(os.path.exists(self.non_empty_file.path))
 
-
-class TestEscapePath(unittest.TestCase):
-    """Tests for escape_path"""
-
-    def test_escape_path(self):
-        """Should escape backslashes and double-quotes"""
-        test_cases_changed = {
-            "\\": "\\\\",
-            '"': '\\"',
-            r'\\\/""\"': r"\\\\\\/\"\"\\\"",
-        }
-        test_cases_unchanged = ["~`!@#$%^&*/()-_'“”=+[]{}|;:,.<>/?", "蟒蛇", "Ŝ≜"]
-        for path, output in test_cases_changed.items():
-            self.assertEqual(run0edit.escape_path(path), output)
-        for case in test_cases_unchanged:
-            self.assertEqual(run0edit.escape_path(case), case)
-
-
-class TestSandboxPath(unittest.TestCase):
-    """Tests for sandbox_path"""
-
-    def setUp(self):
-        """Set up temporary directory"""
-        self.tempdir = new_test_dir()
-
-    def tearDown(self):
-        """Remove temporary directory"""
-        remove_test_dir(self.tempdir)
-
-    def test_path_exists(self):
-        """Should not modify path to existing file without symlinks"""
-        path = f"{self.tempdir}/foo.txt"
-        pathlib.Path(path).touch()
-        self.assertEqual(run0edit.sandbox_path(path), path)
-
-    def test_path_does_not_exist(self):
-        """Should give directory containing path that doesn't exist"""
-        path = f"{self.tempdir}/foo.txt"
-        self.assertEqual(run0edit.sandbox_path(path), self.tempdir)
-
-    def test_symlink_file(self):
-        """Should not follow symlink to file"""
-        file_path = f"{self.tempdir}/foo"
-        symlink_path = f"{self.tempdir}/bar"
-        pathlib.Path(file_path).touch()
-        os.symlink(file_path, symlink_path)
-        self.assertEqual(run0edit.sandbox_path(symlink_path), symlink_path)
-
-    def test_symlink_dir(self):
-        """Should not try to resolve directory symlinks"""
-        dir_path = f"{self.tempdir}/foo"
-        symlink = f"{self.tempdir}/bar"
-        os.mkdir(dir_path)
-        os.symlink(dir_path, symlink)
-        file_path = f"{dir_path}/file.txt"
-        symlinked_file_path = f"{symlink}/file.txt"
-        self.assertEqual(run0edit.sandbox_path(symlinked_file_path), symlink)
-        pathlib.Path(file_path).touch()
-        self.assertEqual(run0edit.sandbox_path(symlinked_file_path), symlinked_file_path)
+    @mock.patch("os.rmdir")
+    @mock.patch("sys.stderr", new_callable=io.StringIO)
+    def test_remove_fail(self, mock_stderr, mock_rmdir):
+        """Should report error message if removing temp dir fails"""
+        mock_rmdir.side_effect = OSError("mock rmdir error")
+        self.empty_file.remove()
+        self.assertIn(
+            "run0edit: Warning: failed to remove temporary directory ", mock_stderr.getvalue()
+        )
+        self.assertFalse(os.path.exists(self.empty_file.path))
 
 
 @mock.patch("run0edit_main.find_command")
@@ -620,14 +572,13 @@ class TestBuildRun0Arguments(unittest.TestCase):
         editor = "/usr/bin/vim"
         args = run0edit.build_run0_arguments(path, temp_path, editor)
         props = run0edit.SYSTEMD_SANDBOX_PROPERTIES
-        self.assertEqual(len(args.systemd_properties), len(props) + 1)
+        self.assertEqual(args.systemd_properties, props)
         self.assertTrue(args.description.startswith("run0edit "))
         self.assertEqual(args._run0_cmd, "/usr/bin/run0")
-        self.assertEqual(args.systemd_properties[-1], f'ReadWritePaths="{path}" "{temp_path}"')
         self.assertEqual(args.extra_options, [])
         self.assertEqual(args.command, "/usr/bin/python3")
         self.assertEqual(args.command_args, [run0edit.INNER_SCRIPT_PATH, path, temp_path, editor])
-        self.assertEqual(len(args.argument_list()), len(props) + 9)
+        self.assertEqual(len(args.argument_list()), len(props) + 8)
         remove_test_file(path)
 
     def test_args_bgcolor(self, mock_find_cmd):
@@ -638,26 +589,14 @@ class TestBuildRun0Arguments(unittest.TestCase):
         editor = "/usr/bin/vim"
         args = run0edit.build_run0_arguments(path, temp_path, editor, bgcolor="bgcolor")
         props = run0edit.SYSTEMD_SANDBOX_PROPERTIES
-        self.assertEqual(len(args.systemd_properties), len(props) + 1)
+        self.assertEqual(args.systemd_properties, props)
         self.assertTrue(args.description.startswith("run0edit "))
         self.assertEqual(args._run0_cmd, "/usr/bin/run0")
-        self.assertEqual(args.systemd_properties[-1], f'ReadWritePaths="{path}" "{temp_path}"')
         self.assertEqual(args.extra_options, ["--background=bgcolor"])
         self.assertEqual(args.command, "/usr/bin/python3")
-        self.assertEqual(
-            args.command_args, [run0edit.INNER_SCRIPT_PATH, path, temp_path, editor, "bgcolor"]
-        )
-        self.assertEqual(len(args.argument_list()), len(props) + 11)
+        self.assertEqual(args.command_args, [run0edit.INNER_SCRIPT_PATH, path, temp_path, editor])
+        self.assertEqual(len(args.argument_list()), len(props) + 9)
         remove_test_file(path)
-
-    def test_read_write_paths(self, mock_find_cmd):
-        """Should escape correct paths in ReadWritePaths"""
-        mock_find_cmd.side_effect = lambda cmd: cmd
-        path = '/blahblah/"foo\\bar/spam.txt'
-        temp_path = '"temp"/file'
-        args = run0edit.build_run0_arguments(path, temp_path, "...")
-        rw_paths = r'ReadWritePaths="/blahblah/\"foo\\bar" "\"temp\"/file"'
-        self.assertIn(rw_paths, args.systemd_properties)
 
     def test_debug_arg(self, mock_find_cmd):
         """Should set environment variable with debug option"""
@@ -756,7 +695,7 @@ class TestValidatePath(unittest.TestCase):
         run0edit.validate_path(self.path)
 
 
-@mock.patch("subprocess.run")
+@mock.patch("os.execv")
 @mock.patch("run0edit_main.find_command", lambda cmd: f"/usr/bin/{cmd}")
 class TestRun(unittest.TestCase):
     """Tests for run"""
@@ -770,117 +709,68 @@ class TestRun(unittest.TestCase):
         remove_test_file(self.path)
 
     @mock.patch("run0edit_main.validate_path")
-    def test_validates_path_succeeded(self, mock_validate, mock_subproc):
+    def test_validates_path_succeeded(self, mock_validate, mock_execv):
         """Should validate path and continue if valid"""
         mock_validate.return_value = None
         run0edit.run(self.path, "...")
         self.assertEqual(mock_validate.call_args.args, (self.path,))
-        self.assertTrue(mock_subproc.called)
+        self.assertTrue(mock_execv.called)
 
     @mock.patch("run0edit_main.print_err")
     @mock.patch("run0edit_main.validate_path")
-    def test_path_validation_failed(self, mock_validate, mock_print_err, mock_subproc):
+    def test_path_validation_failed(self, mock_validate, mock_print_err, mock_execv):
         """Should validate path and exit with an error message if not valid"""
         mock_validate.side_effect = run0edit.InvalidPathError("some error message")
         self.assertEqual(run0edit.run(self.path, "..."), 1)
         self.assertEqual(mock_validate.call_args.args, (self.path,))
         self.assertEqual(mock_print_err.call_args.args, ("some error message",))
-        self.assertFalse(mock_subproc.called)
+        self.assertFalse(mock_execv.called)
 
-    def test_creates_temp_file(self, mock_subproc):
-        """Should create empty temp file that's passed to subprocess.run"""
-        mock_subproc.side_effect = Exception("mock subproc")
-        editor = "/bin/ed"
-        with self.assertRaisesRegex(Exception, "mock subproc"):
-            run0edit.run(self.path, editor)
-        (args,) = mock_subproc.call_args.args
-        temp_filename = args[-2]
-        self.assertNotEqual(self.path, temp_filename)
-        self.assertTrue(os.path.isfile(temp_filename))
-        self.assertEqual(os.path.getsize(temp_filename), 0)
-        os.remove(temp_filename)
-        os.rmdir(os.path.dirname(temp_filename))
-
-    @mock.patch("os.geteuid")
-    def test_check_args(self, mock_geteuid, mock_subproc):
-        """Should pass expected arguments to subprocess.run"""
-        mock_geteuid.return_value = 1
+    def test_check_args(self, mock_execv):
+        """Should pass expected arguments to os.execv"""
         editor = "/usr/sbin/butterfly"
         run0edit.run(self.path, editor)
-        (args,) = mock_subproc.call_args.args
+        (
+            run0_cmd,
+            args,
+        ) = mock_execv.call_args.args
+        self.assertEqual(run0_cmd, "/usr/bin/run0")
         temp_filename = args[-2]
         expected_args = run0edit.build_run0_arguments(self.path, temp_filename, editor)
         self.assertEqual(args, expected_args.argument_list())
-        kwargs = mock_subproc.call_args.kwargs
-        self.assertEqual(kwargs, {"env": mock.ANY, "check": False})
-        false_bool_strings = ("0", "no", "n", "false", "f", "off")
-        self.assertNotIn(kwargs["env"].get("SYSTEMD_ADJUST_TERMINAL_TITLE"), false_bool_strings)
-
-    @mock.patch("os.geteuid")
-    def test_adjust_terminal_title(self, mock_geteuid, mock_subproc):
-        """Should not adjust terminal title if run as root"""
-        mock_geteuid.return_value = 0
-        editor = "/usr/sbin/butterfly"
-        run0edit.run(self.path, editor)
-        env = mock_subproc.call_args.kwargs["env"]
-        self.assertEqual(env.get("SYSTEMD_ADJUST_TERMINAL_TITLE"), "false")
 
     @staticmethod
-    def mock_editor_process(args: Sequence[str], **_: Any) -> int:
-        """Mock subprocess.run that writes text to temp file"""
+    def mock_editor_process(_path: str, args: Sequence[str], **_: Any) -> int:
+        """Mock os.execv that writes text to temp file"""
         text = os.environ.get("MOCK_TEXT")
         if text is not None:
             with open(args[-2], "w", encoding="utf8") as f:
                 f.write(os.environ["MOCK_TEXT"])
-        ret = mock.Mock()
-        ret.returncode = int(os.environ["MOCK_RETCODE"])
-        return ret
+        return int(os.environ["MOCK_RETCODE"])
 
     @mock.patch("sys.stderr", new_callable=io.StringIO)
-    def test_run_success(self, mock_stderr, mock_subproc):
-        """Should clean up temp file and return 0 if subprocess succeeds"""
-        mock_subproc.side_effect = self.mock_editor_process
+    def test_run_success(self, mock_stderr, mock_execv):
+        """Should clean up temp file and return 0 if execv succeeds"""
+        mock_execv.side_effect = self.mock_editor_process
         with mock.patch.dict("os.environ", {"MOCK_TEXT": "foo", "MOCK_RETCODE": "0"}):
             self.assertEqual(run0edit.run(self.path, "..."), 0)
-        (args,) = mock_subproc.call_args.args
+        (
+            run0_cmd,
+            args,
+        ) = mock_execv.call_args.args
+        self.assertEqual(run0_cmd, "/usr/bin/run0")
         temp_filename = args[-2]
         self.assertFalse(os.path.exists(temp_filename))
         self.assertEqual(mock_stderr.getvalue(), "")
 
     @mock.patch("sys.stderr", new_callable=io.StringIO)
-    def test_run_fail_nonempty(self, mock_stderr, mock_subproc):
-        """Should return nonzero and not clean non-empty tempfile if subprocess fails"""
-        mock_subproc.side_effect = self.mock_editor_process
-        with mock.patch.dict("os.environ", {"MOCK_TEXT": "foo", "MOCK_RETCODE": "42"}):
-            self.assertEqual(run0edit.run(self.path, "..."), 42)
-        (args,) = mock_subproc.call_args.args
-        temp_filename = args[-2]
-        self.assertTrue(os.path.exists(temp_filename))
-        os.remove(temp_filename)
-        os.rmdir(os.path.dirname(temp_filename))
-        self.assertEqual(mock_stderr.getvalue(), "")
-
-    @mock.patch("sys.stderr", new_callable=io.StringIO)
-    def test_run_fail_empty(self, mock_stderr, mock_subproc):
-        """Should return nonzero and clean empty tempfile if subprocess fails"""
-        mock_subproc.side_effect = self.mock_editor_process
-        with mock.patch.dict("os.environ", {"MOCK_RETCODE": "5"}):
-            self.assertEqual(run0edit.run(self.path, "..."), 5)
-        (args,) = mock_subproc.call_args.args
-        temp_filename = args[-2]
+    def test_execv_fail(self, mock_stderr, mock_execv):
+        """Should return 1 and clean empty tempfile if execv fails"""
+        mock_execv.side_effect = OSError("mock execv error")
+        self.assertEqual(run0edit.run(self.path, "..."), 1)
+        temp_filename = mock_execv.call_args.args[0][-2]
         self.assertFalse(os.path.exists(temp_filename))
-        self.assertEqual(mock_stderr.getvalue(), "")
-
-    @mock.patch("sys.stderr", new_callable=io.StringIO)
-    def test_run_namespace_creation_fail(self, mock_stderr, mock_subproc):
-        """Should return 1 and clean tempfile if subprocess fails with exit status 226"""
-        mock_subproc.side_effect = self.mock_editor_process
-        with mock.patch.dict("os.environ", {"MOCK_TEXT": "foo", "MOCK_RETCODE": "226"}):
-            self.assertEqual(run0edit.run(self.path, "..."), 1)
-        (args,) = mock_subproc.call_args.args
-        temp_filename = args[-2]
-        self.assertFalse(os.path.exists(temp_filename))
-        self.assertIn("No such directory", mock_stderr.getvalue())
+        self.assertEqual(mock_stderr.getvalue(), "run0edit: Warning: execution of run0 failed\n")
 
 
 class TestAnsiColor(unittest.TestCase):
@@ -1133,7 +1023,7 @@ class TestMain(unittest.TestCase):
         self.assertEqual(mock_stdout.getvalue(), "")
         self.assertRegex(
             mock_stderr.getvalue().replace("\n", " "),
-            "^run0edit: ERROR: Inner script was not found .* or did not have expected SHA-256 hash",
+            "^run0edit: ERROR: Inner script was not found .* or did not have expected BLAKE2 hash",
         )
 
     @mock.patch("sys.argv", ["run0edit", "nano", "asdf"])


### PR DESCRIPTION
Use execv to replace the main process with the privileged process instead of spawning a subprocess. Also use `runuser` instead of `run0` in the privileged script to avoid nested DBus calls and allow for a more robust sandbox.

Fixes #91. (However, independent of anything run0edit does, note that Polkit auth caching may still fail on systems with a stricter default umask due to https://github.com/polkit-org/polkit/issues/655.)