### PR TITLE
fix: grant CAP_SYS_NICE and CAP_SYS_RESOURCE to inner script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 
 # Changelog
 
+## [v0.6.1] - 2026-08-23
+
+- Grant the privileged inner script the additional capabilities `CAP_SYS_NICE`
+  and `CAP_SYS_RESOURCE` to avoid permission errors if `pam_limits` needs to set
+  resource limits in the `runuser` call.
+  ([#108](https://github.com/HastD/run0edit/pull/108))
+
 ## [v0.6.0] - 2026-08-22
 
 This version contains two significant changes to run0edit's execution model.

--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,7 @@
 
 project(
     'run0edit',
-    version: '0.6.0',
+    version: '0.6.1',
     meson_version: '>= 1.3.0',
     license: 'Apache-2.0 OR MIT',
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 
 [project]
 name = "run0edit"
-version = "0.6.0"
+version = "0.6.1"
 requires-python = ">= 3.10"
 authors = [
     {name = "Daniel Hast"},

--- a/rpm/run0edit.spec
+++ b/rpm/run0edit.spec
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 
 Name:           run0edit
-Version:        0.6.0
+Version:        0.6.1
 Release:        1
 Summary:        run0edit allows a permitted user to edit a file as root.
 
@@ -47,6 +47,9 @@ copied back to the original location when the editor is closed.
 %{_mandir}/man1/%{name}.1*
 
 %changelog
+* Sun Aug 23 2026 Daniel Hast <hast.daniel@protonmail.com> - v0.6.1
+- Grant CAP_SYS_NICE and CAP_SYS_RESOURCE capabilities to inner script.
+
 * Sat Aug 22 2026 Daniel Hast <hast.daniel@protonmail.com> - v0.6.0
 - Use execv to replace main process with privileged process. This makes run0edit
   work properly with Polkit's authentication caching.

--- a/run0edit_main.py.in
+++ b/run0edit_main.py.in
@@ -37,6 +37,8 @@ CAPABILITY_BOUNDING_SET: Final[list[str]] = [
     "CAP_LINUX_IMMUTABLE",
     "CAP_SETGID",
     "CAP_SETUID",
+    "CAP_SYS_NICE",
+    "CAP_SYS_RESOURCE",
 ]
 
 SYSTEM_CALL_DENY: Final[list[str]] = [


### PR DESCRIPTION
This ensures `pam_limits` is able to raise resource limits as needed in the `runuser` call.

Fixes #107.